### PR TITLE
Move contributor tracking to GitHub

### DIFF
--- a/assets/rust-shaders/src/motion_blur.rs
+++ b/assets/rust-shaders/src/motion_blur.rs
@@ -1,5 +1,3 @@
-// Rust-GPU port of `motion_blur.hlsl` by Viktor Zoutman
-
 use crate::{
     frame_constants::FrameConstants,
     util::{depth_to_view_z, get_uv_u},

--- a/assets/rust-shaders/src/rev_blur.rs
+++ b/assets/rust-shaders/src/rev_blur.rs
@@ -1,5 +1,3 @@
-// Rust-GPU port of `rev_blur.hlsl` by Henrik Rydgård
-
 use spirv_std::{Image, Sampler};
 
 use macaw::{UVec3, Vec2, Vec4};

--- a/crates/bin/bake/Cargo.toml
+++ b/crates/bin/bake/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "bake"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bin/hello/Cargo.toml
+++ b/crates/bin/hello/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bin/view/Cargo.toml
+++ b/crates/bin/view/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "view"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/lib/kajiya-asset/Cargo.toml
+++ b/crates/lib/kajiya-asset/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kajiya-asset"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/lib/kajiya-backend/Cargo.toml
+++ b/crates/lib/kajiya-backend/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kajiya-backend"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/lib/kajiya-backend/src/rust_shader_compiler.rs
+++ b/crates/lib/kajiya-backend/src/rust_shader_compiler.rs
@@ -117,7 +117,6 @@ impl LazyWorker for CompileRustShaderCrate {
     }
 }
 
-// Based on code by Viktor Zoutman
 // Runs cargo in a sub-process to execute the rust shader builder.
 fn compile_rust_shader_crate_thread(
     cancel_rx: std::sync::mpsc::Receiver<()>,

--- a/crates/lib/kajiya-imgui/Cargo.toml
+++ b/crates/lib/kajiya-imgui/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kajiya-imgui"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/lib/kajiya-rg/Cargo.toml
+++ b/crates/lib/kajiya-rg/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kajiya-rg"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/lib/kajiya-simple/Cargo.toml
+++ b/crates/lib/kajiya-simple/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kajiya-simple"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/lib/kajiya/Cargo.toml
+++ b/crates/lib/kajiya/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "kajiya"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/misc/metalness_norm/Cargo.toml
+++ b/misc/metalness_norm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "metalness_norm"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/misc/spatial_sample_gen/Cargo.toml
+++ b/misc/spatial_sample_gen/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "spatial_sample_gen"
 version = "0.1.0"
-authors = ["Tomasz Stachowiak <h3@h3.gd>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Since the project is going Open Source, tracking individual contributions manually in the source code seems silly. Still useful for snippets and algorithms nicked or inspired from external developers, but I think this is going to be simpler 😄

I've kept the `authors` entry in the `Cargo.toml` for `ash-imgui` as that one is forked from Simon Brown's work, with some modifications from me.