### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,6 @@ dependencies = [
  "futures",
  "glam",
  "kajiya-asset",
- "kajiya-backend",
  "num_cpus",
  "smol",
  "structopt",
@@ -1393,21 +1392,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "array-init",
- "arrayvec",
- "async-channel",
- "async-executor",
  "blue-noise-sampler",
- "byte-slice-cast",
- "byteorder",
  "chrono",
- "derive_builder",
  "easy-parallel",
- "failure",
  "fern",
- "futures",
  "glam",
- "hassle-rs",
- "hotwatch",
  "image",
  "kajiya-asset",
  "kajiya-backend",
@@ -1417,13 +1406,8 @@ dependencies = [
  "memmap2 0.2.3",
  "ngx_dlss",
  "parking_lot",
- "raw-window-handle",
- "relative-path",
- "ron",
  "rust-shaders-shared",
  "smol",
- "structopt",
- "thiserror",
  "turbosloth",
  "wchar",
 ]
@@ -1441,7 +1425,6 @@ dependencies = [
  "image",
  "kajiya-backend",
  "log",
- "serde",
  "turbosloth",
  "urlencoding",
 ]
@@ -1483,15 +1466,12 @@ dependencies = [
 name = "kajiya-imgui"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "ash-imgui",
- "glam",
  "imgui",
  "imgui-winit-support",
  "kajiya",
  "log",
  "parking_lot",
- "turbosloth",
  "winit",
 ]
 
@@ -1501,9 +1481,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrayvec",
- "derive_builder",
- "futures",
- "glam",
  "kajiya-backend",
  "lazy_static",
  "log",
@@ -1517,17 +1494,13 @@ name = "kajiya-simple"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ash-imgui",
  "glam",
  "imgui",
- "imgui-winit-support",
  "kajiya",
  "kajiya-imgui",
  "log",
- "parking_lot",
  "puffin",
  "puffin_http",
- "serde",
  "turbosloth",
  "winit",
 ]
@@ -2811,20 +2784,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dolly",
- "futures",
- "glam",
  "imgui",
  "kajiya",
  "kajiya-simple",
- "lazy_static",
  "log",
- "parking_lot",
  "ron",
  "serde",
- "smol",
  "structopt",
- "turbosloth",
- "winit",
 ]
 
 [[package]]

--- a/crates/bin/bake/Cargo.toml
+++ b/crates/bin/bake/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 kajiya-asset = { path = "../../lib/kajiya-asset" }
-kajiya-backend = { path = "../../lib/kajiya-backend" }
 
 anyhow = "1.0"
 async-channel = "1.6"

--- a/crates/bin/view/Cargo.toml
+++ b/crates/bin/view/Cargo.toml
@@ -11,18 +11,11 @@ kajiya-simple = { path = "../../lib/kajiya-simple", features = ["dear-imgui"] }
 
 anyhow = "1.0"
 dolly = "0.1"
-futures = "0.3"
-glam = { version = "0.18", features = ["serde"] }
 imgui = "0.7"
-lazy_static = "1.4"
 log = "0.4"
-parking_lot = "0.11"
 ron = "0.6.2"
 serde = { version = "1.0", features = ["derive"] }
-smol = "1.2.5"
 structopt = "0.3"
-turbosloth = { git = "https://github.com/h3r2tic/turbosloth.git", rev = "92030af" }
-winit = "0.25"
 
 [features]
 dlss = ["kajiya/dlss"]

--- a/crates/lib/kajiya-asset/Cargo.toml
+++ b/crates/lib/kajiya-asset/Cargo.toml
@@ -16,6 +16,5 @@ glam = "0.18"
 gltf = { git = "https://github.com/h3r2tic/gltf.git", rev = "83826e3", features = ["KHR_texture_transform"] } # u8 color import fix
 image = { version = "0.23.13", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt"] }
 log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
 turbosloth = { git = "https://github.com/h3r2tic/turbosloth.git", rev = "92030af" }
 urlencoding = "2.1"

--- a/crates/lib/kajiya-imgui/Cargo.toml
+++ b/crates/lib/kajiya-imgui/Cargo.toml
@@ -8,12 +8,9 @@ edition = "2021"
 [dependencies]
 kajiya = { path = "../kajiya" }
 
-anyhow = "1.0"
 ash-imgui = { path = "../ash-imgui" }
-glam = "0.18"
 imgui = { version = "0.7" }
 imgui-winit-support = { version = "0.7", default-features = false, features = ["winit-25"] }
 log = "0.4"
 parking_lot = "0.11"
-turbosloth = { git = "https://github.com/h3r2tic/turbosloth.git", rev = "92030af" }
 winit = "0.25"

--- a/crates/lib/kajiya-rg/Cargo.toml
+++ b/crates/lib/kajiya-rg/Cargo.toml
@@ -10,9 +10,6 @@ kajiya-backend = { path = "../kajiya-backend" }
 
 anyhow = "1.0"
 arrayvec = "0.5"
-derive_builder = { version = "0.9", default-features = false }
-futures = "0.3"
-glam = "0.18"
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11"

--- a/crates/lib/kajiya-simple/Cargo.toml
+++ b/crates/lib/kajiya-simple/Cargo.toml
@@ -12,22 +12,16 @@ kajiya-imgui = { path = "../kajiya-imgui", optional = true }
 anyhow = "1.0"
 glam = { version = "0.18", features = ["serde"] }
 log = "0.4"
-parking_lot = "0.11"
 puffin = { version = "0.11.0" }
-serde = { version = "1.0", features = ["derive"] }
 turbosloth = { git = "https://github.com/h3r2tic/turbosloth.git", rev = "92030af" }
 winit = "0.25"
 
 puffin_http = { version = "0.8.0", optional = true }
-ash-imgui = { path = "../ash-imgui", optional = true }
 imgui = { version = "0.7", optional = true }
-imgui-winit-support = { version = "0.7", default-features = false, features = ["winit-25"], optional = true }
 
 [features]
 dear-imgui = [
-    "ash-imgui",
     "imgui",
-    "imgui-winit-support",
     "kajiya-imgui",
 ]
 puffin-server = [

--- a/crates/lib/kajiya/Cargo.toml
+++ b/crates/lib/kajiya/Cargo.toml
@@ -13,36 +13,21 @@ rust-shaders-shared = { path = "../rust-shaders-shared" }
 
 anyhow = "1.0"
 array-init = "2.0.0"
-arrayvec = "0.5"
 blue-noise-sampler = "0.1"
-byte-slice-cast = "0.3"
-byteorder = "1.4"
 chrono = "0.4"
-derive_builder = { version = "0.9", default-features = false }
-failure = "0.1.8"   # for shader-prepper: TODO: NUKE
 fern = { version = "0.6", features = ["colored"] }
-futures = "0.3"
 glam = { version = "0.18" }
-hassle-rs = "0.4"
-hotwatch = "0.4"
 image = { version = "0.23.13", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt"] }
 lazy_static = "1.4"
 log = "0.4"
 memmap2 = "0.2"
 parking_lot = "0.11"
-raw-window-handle = "0.3"
-relative-path = "1.3"
-ron = "0.6.2"
 smol = "1.2.5"
-structopt = "0.3"
-thiserror = "1.0"
 turbosloth = { git = "https://github.com/h3r2tic/turbosloth.git", rev = "92030af" }
 
 ngx_dlss = { path = "../ngx_dlss", optional = true }
 wchar = "0.10"
 
-async-channel = "1.4.2"
-async-executor = "1.1.0"
 easy-parallel = "3.1.0"
 
 [features]


### PR DESCRIPTION
These were moved from crate to crate during development, most likely. It might speed up compile times a bit, by removing build dependencies between crates.