### PR TITLE
Fix scratch buffer usage flags according to validation layers

### DIFF
--- a/crates/lib/kajiya-backend/src/vulkan/ray_tracing.rs
+++ b/crates/lib/kajiya-backend/src/vulkan/ray_tracing.rs
@@ -85,7 +85,7 @@ impl Device {
             .create_buffer(
                 super::buffer::BufferDesc {
                     size: INITIAL_SIZE,
-                    usage: vk::BufferUsageFlags::ACCELERATION_STRUCTURE_STORAGE_KHR
+                    usage: vk::BufferUsageFlags::STORAGE_BUFFER
                         | vk::BufferUsageFlags::SHADER_DEVICE_ADDRESS,
                     mapped: false,
                 },


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

At the moment I get this validation error:

`
VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674(ERROR / SPEC): msgNum: -362882317 - Validation Error: [ VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674 ] Object 0: handle = 0x1499e3a13e0, type = VK_OBJ
ECT_TYPE_DEVICE; | MessageID = 0xea5edaf3 | vkBuildAccelerationStructuresKHR(): The buffer associated with pInfos[0].scratchData.deviceAddress was not created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT bit. The Vulka
n spec states: The buffer from which the buffer device address pInfos[i].scratchData.deviceAddress is queried must have been created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT usage flag (https://vulkan.lunarg.com/do
c/view/1.2.198.0/windows/1.2-extensions/vkspec.html#VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674)
` 

I'm using the 1.2.198 Vulkan SDK on Windows with a AMD 6900XT - it's possible that this validation error is device-specific and that you do need `vk::BufferUsageFlags::ACCELERATION_STRUCTURE_STORAGE_KHR` on Nvidia but I'm not sure.

### Related Issues

List related issues here
