### PR TITLE
Use the primary monitor for exclusive fullscreen instead of the first available monitor

### DIFF
--- a/crates/lib/kajiya-simple/src/main_loop.rs
+++ b/crates/lib/kajiya-simple/src/main_loop.rs
@@ -194,8 +194,7 @@ impl SimpleMainLoop {
                 FullscreenMode::Borderless => Some(Fullscreen::Borderless(None)),
                 FullscreenMode::Exclusive => Some(Fullscreen::Exclusive(
                     event_loop
-                        .available_monitors()
-                        .next()
+                        .primary_monitor()
                         .expect("at least one monitor")
                         .video_modes()
                         .next()


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

So I don't really understand how available monitors in `winit` are sorted, but for me the current code puts the window onto my internal monitor, instead of the primary external one. Using whatever is considered as the primary monitor feels like the proper behaviour.