### PR TITLE
Allow scale to be set of an instance mesh

### DIFF
--- a/assets/shaders/rt/gbuffer.rchit.hlsl
+++ b/assets/shaders/rt/gbuffer.rchit.hlsl
@@ -73,7 +73,10 @@ void main(inout GbufferRayPayload payload: SV_RayPayload, in RayHitAttrib attrib
     float2 uv = uv0 * barycentrics.x + uv1 * barycentrics.y + uv2 * barycentrics.z;
 
     const float cone_width = payload.ray_cone.width_at_t(hit_dist);
-    const float lod_triangle_constant = 0.5 * log2(twice_uv_area(uv0, uv1, uv2) / twice_triangle_area(v0.position, v1.position, v2.position));
+    const float3 v0_pos_ws = mul(ObjectToWorld3x4(), float4(v0.position, 1.0));
+    const float3 v1_pos_ws = mul(ObjectToWorld3x4(), float4(v1.position, 1.0));
+    const float3 v2_pos_ws = mul(ObjectToWorld3x4(), float4(v2.position, 1.0));
+    const float lod_triangle_constant = 0.5 * log2(twice_uv_area(uv0, uv1, uv2) / twice_triangle_area(v0_pos_ws, v1_pos_ws, v2_pos_ws));
 
     uint material_id = vertices.Load(ind.x * sizeof(uint) + mesh.vertex_mat_offset);
     MeshMaterial material = vertices.Load<MeshMaterial>(mesh.mat_data_offset + material_id * sizeof(MeshMaterial));

--- a/crates/bin/hello/src/main.rs
+++ b/crates/bin/hello/src/main.rs
@@ -22,9 +22,10 @@ fn main() -> anyhow::Result<()> {
         .world_renderer
         .add_baked_mesh("/baked/336_lrm.mesh", AddMeshOptions::new())?;
 
-    let car_inst = kajiya
-        .world_renderer
-        .add_instance(car_mesh, Vec3::ZERO, Quat::IDENTITY);
+    let car_inst = kajiya.world_renderer.add_instance(
+        car_mesh,
+        Affine3A::from_rotation_translation(Quat::IDENTITY, Vec3::ZERO),
+    );
 
     let mut car_rot = 0.0f32;
 

--- a/crates/bin/hello/src/main.rs
+++ b/crates/bin/hello/src/main.rs
@@ -32,8 +32,7 @@ fn main() -> anyhow::Result<()> {
         car_rot += 0.5 * ctx.dt_filtered;
         ctx.world_renderer.set_instance_transform(
             car_inst,
-            Vec3::ZERO,
-            Quat::from_rotation_y(car_rot),
+            Affine3A::from_rotation_translation(Quat::from_rotation_y(car_rot), Vec3::ZERO),
         );
 
         WorldFrameDesc {

--- a/crates/bin/view/src/main.rs
+++ b/crates/bin/view/src/main.rs
@@ -176,8 +176,7 @@ fn main() -> anyhow::Result<()> {
         )?;
         render_instances.push(kajiya.world_renderer.add_instance(
             mesh,
-            instance.position.into(),
-            Quat::IDENTITY,
+            Affine3A::from_rotation_translation(Quat::IDENTITY, instance.position.into()),
         ));
     }
 

--- a/crates/lib/kajiya-backend/src/vulkan/ray_tracing.rs
+++ b/crates/lib/kajiya-backend/src/vulkan/ray_tracing.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use ash::vk;
 use byte_slice_cast::AsSliceOf;
 use bytes::Bytes;
-use glam::{Mat3, Vec3};
+use glam::Affine3A;
 use parking_lot::Mutex;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -42,8 +42,7 @@ pub struct RayTracingGeometryDesc {
 #[derive(Clone)]
 pub struct RayTracingInstanceDesc {
     pub blas: Arc<RayTracingAcceleration>,
-    pub position: Vec3,
-    pub rotation: Mat3,
+    pub transformation: Affine3A,
     pub mesh_index: u32,
 }
 
@@ -196,19 +195,19 @@ impl Device {
                         )
                 };
 
-                let transform: [f32; 12] = [
-                    desc.rotation.x_axis.x,
-                    desc.rotation.y_axis.x,
-                    desc.rotation.z_axis.x,
-                    desc.position.x,
-                    desc.rotation.x_axis.y,
-                    desc.rotation.y_axis.y,
-                    desc.rotation.z_axis.y,
-                    desc.position.y,
-                    desc.rotation.x_axis.z,
-                    desc.rotation.y_axis.z,
-                    desc.rotation.z_axis.z,
-                    desc.position.z,
+                let transform = [
+                    desc.transformation.x_axis.x,
+                    desc.transformation.y_axis.x,
+                    desc.transformation.z_axis.x,
+                    desc.transformation.translation.x,
+                    desc.transformation.x_axis.y,
+                    desc.transformation.y_axis.y,
+                    desc.transformation.z_axis.y,
+                    desc.transformation.translation.y,
+                    desc.transformation.x_axis.z,
+                    desc.transformation.y_axis.z,
+                    desc.transformation.z_axis.z,
+                    desc.transformation.translation.z,
                 ];
 
                 GeometryInstance::new(
@@ -409,19 +408,19 @@ impl Device {
                     )
             };
 
-            let transform: [f32; 12] = [
-                desc.rotation.x_axis.x,
-                desc.rotation.y_axis.x,
-                desc.rotation.z_axis.x,
-                desc.position.x,
-                desc.rotation.x_axis.y,
-                desc.rotation.y_axis.y,
-                desc.rotation.z_axis.y,
-                desc.position.y,
-                desc.rotation.x_axis.z,
-                desc.rotation.y_axis.z,
-                desc.rotation.z_axis.z,
-                desc.position.z,
+            let transform = [
+                desc.transformation.x_axis.x,
+                desc.transformation.y_axis.x,
+                desc.transformation.z_axis.x,
+                desc.transformation.translation.x,
+                desc.transformation.x_axis.y,
+                desc.transformation.y_axis.y,
+                desc.transformation.z_axis.y,
+                desc.transformation.translation.y,
+                desc.transformation.x_axis.z,
+                desc.transformation.y_axis.z,
+                desc.transformation.z_axis.z,
+                desc.transformation.translation.z,
             ];
 
             GeometryInstance::new(

--- a/crates/lib/kajiya/src/renderers/raster_meshes.rs
+++ b/crates/lib/kajiya/src/renderers/raster_meshes.rs
@@ -77,34 +77,34 @@ pub fn raster_meshes(
         let instance_transforms_offset =
             api.dynamic_constants()
                 .push_from_iter(instances.iter().map(|inst| {
-                    let transform: [f32; 12] = [
-                        inst.rotation.x_axis.x,
-                        inst.rotation.y_axis.x,
-                        inst.rotation.z_axis.x,
-                        inst.position.x,
-                        inst.rotation.x_axis.y,
-                        inst.rotation.y_axis.y,
-                        inst.rotation.z_axis.y,
-                        inst.position.y,
-                        inst.rotation.x_axis.z,
-                        inst.rotation.y_axis.z,
-                        inst.rotation.z_axis.z,
-                        inst.position.z,
+                    let transform = [
+                        inst.transformation.x_axis.x,
+                        inst.transformation.y_axis.x,
+                        inst.transformation.z_axis.x,
+                        inst.transformation.translation.x,
+                        inst.transformation.x_axis.y,
+                        inst.transformation.y_axis.y,
+                        inst.transformation.z_axis.y,
+                        inst.transformation.translation.y,
+                        inst.transformation.x_axis.z,
+                        inst.transformation.y_axis.z,
+                        inst.transformation.z_axis.z,
+                        inst.transformation.translation.z,
                     ];
 
-                    let prev_transform: [f32; 12] = [
-                        inst.prev_rotation.x_axis.x,
-                        inst.prev_rotation.y_axis.x,
-                        inst.prev_rotation.z_axis.x,
-                        inst.prev_position.x,
-                        inst.prev_rotation.x_axis.y,
-                        inst.prev_rotation.y_axis.y,
-                        inst.prev_rotation.z_axis.y,
-                        inst.prev_position.y,
-                        inst.prev_rotation.x_axis.z,
-                        inst.prev_rotation.y_axis.z,
-                        inst.prev_rotation.z_axis.z,
-                        inst.prev_position.z,
+                    let prev_transform = [
+                        inst.prev_transformation.x_axis.x,
+                        inst.prev_transformation.y_axis.x,
+                        inst.prev_transformation.z_axis.x,
+                        inst.prev_transformation.translation.x,
+                        inst.prev_transformation.x_axis.y,
+                        inst.prev_transformation.y_axis.y,
+                        inst.prev_transformation.z_axis.y,
+                        inst.prev_transformation.translation.y,
+                        inst.prev_transformation.x_axis.z,
+                        inst.prev_transformation.y_axis.z,
+                        inst.prev_transformation.z_axis.z,
+                        inst.prev_transformation.translation.z,
                     ];
 
                     (transform, prev_transform)

--- a/crates/lib/kajiya/src/world_renderer.rs
+++ b/crates/lib/kajiya/src/world_renderer.rs
@@ -8,7 +8,7 @@ use crate::{
         rtr::*, shadow_denoise::ShadowDenoiseRenderer, ssgi::*, taa::TaaRenderer,
     },
 };
-use glam::{Affine3A, Quat, Vec2, Vec3};
+use glam::{Affine3A, Vec2, Vec3};
 use kajiya_asset::mesh::{AssetRef, GpuImage, MeshMaterialFlags, PackedTriMesh, PackedVertex};
 use kajiya_backend::{
     ash::vk::{self, ImageView},
@@ -624,19 +624,13 @@ impl WorldRenderer {
         MeshHandle(mesh_idx)
     }
 
-    pub fn add_instance(
-        &mut self,
-        mesh: MeshHandle,
-        position: Vec3,
-        rotation: Quat,
-    ) -> InstanceHandle {
+    pub fn add_instance(&mut self, mesh: MeshHandle, transform: Affine3A) -> InstanceHandle {
         let handle = self.next_instance_handle;
         self.next_instance_handle += 1;
         let handle = InstanceHandle(handle);
 
         let index = self.instances.len();
 
-        let transform = Affine3A::from_rotation_translation(rotation, position);
         self.instances.push(MeshInstance {
             transformation: transform,
             prev_transformation: transform,

--- a/crates/lib/kajiya/src/world_renderer.rs
+++ b/crates/lib/kajiya/src/world_renderer.rs
@@ -8,7 +8,7 @@ use crate::{
         rtr::*, shadow_denoise::ShadowDenoiseRenderer, ssgi::*, taa::TaaRenderer,
     },
 };
-use glam::{Mat3, Quat, Vec2, Vec3};
+use glam::{Affine3A, Quat, Vec2, Vec3};
 use kajiya_asset::mesh::{AssetRef, GpuImage, MeshMaterialFlags, PackedTriMesh, PackedVertex};
 use kajiya_backend::{
     ash::vk::{self, ImageView},
@@ -70,10 +70,8 @@ impl Default for InstanceDynamicParameters {
 
 #[derive(Clone, Copy)]
 pub struct MeshInstance {
-    pub rotation: Mat3,
-    pub position: Vec3,
-    pub prev_rotation: Mat3,
-    pub prev_position: Vec3,
+    pub transformation: Affine3A,
+    pub prev_transformation: Affine3A,
     pub mesh: MeshHandle,
     pub dynamic_parameters: InstanceDynamicParameters,
 }
@@ -637,13 +635,11 @@ impl WorldRenderer {
         let handle = InstanceHandle(handle);
 
         let index = self.instances.len();
-        let rotation_mat = Mat3::from_quat(rotation);
 
+        let transform = Affine3A::from_rotation_translation(rotation, position);
         self.instances.push(MeshInstance {
-            rotation: rotation_mat,
-            position,
-            prev_rotation: rotation_mat,
-            prev_position: position,
+            transformation: transform,
+            prev_transformation: transform,
             mesh,
             dynamic_parameters: InstanceDynamicParameters::default(),
         });
@@ -671,10 +667,9 @@ impl WorldRenderer {
         }
     }
 
-    pub fn set_instance_transform(&mut self, inst: InstanceHandle, position: Vec3, rotation: Quat) {
+    pub fn set_instance_transform(&mut self, inst: InstanceHandle, transform: Affine3A) {
         let index = self.instance_handle_to_index[&inst];
-        self.instances[index].position = position;
-        self.instances[index].rotation = Mat3::from_quat(rotation);
+        self.instances[index].transformation = transform;
     }
 
     pub fn get_instance_dynamic_parameters(
@@ -704,8 +699,7 @@ impl WorldRenderer {
                         .iter()
                         .map(|inst| RayTracingInstanceDesc {
                             blas: self.mesh_blas[inst.mesh.0].clone(),
-                            position: inst.position,
-                            rotation: inst.rotation,
+                            transformation: inst.transformation,
                             mesh_index: inst.mesh.0 as u32,
                         })
                         .collect::<Vec<_>>(),
@@ -737,8 +731,7 @@ impl WorldRenderer {
             .iter()
             .map(|inst| RayTracingInstanceDesc {
                 blas: self.mesh_blas[inst.mesh.0].clone(),
-                position: inst.position,
-                rotation: inst.rotation,
+                transformation: inst.transformation,
                 mesh_index: inst.mesh.0 as u32,
             })
             .collect::<Vec<_>>();
@@ -772,8 +765,7 @@ impl WorldRenderer {
 
     fn store_prev_mesh_transforms(&mut self) {
         for inst in &mut self.instances {
-            inst.prev_position = inst.position;
-            inst.prev_rotation = inst.rotation;
+            inst.prev_transformation = inst.transformation;
         }
     }
 
@@ -858,8 +850,10 @@ impl WorldRenderer {
             .instances
             .iter()
             .flat_map(|inst| {
-                let inst_position = inst.position;
-                let inst_rotation = inst.rotation;
+                let (_scale, roation, translation) =
+                    inst.transformation.to_scale_rotation_translation();
+                let inst_position = translation;
+                let inst_rotation = roation;
 
                 let emissive_multiplier = Vec3::splat(inst.dynamic_parameters.emissive_multiplier);
 

--- a/crates/lib/kajiya/src/world_renderer.rs
+++ b/crates/lib/kajiya/src/world_renderer.rs
@@ -853,7 +853,7 @@ impl WorldRenderer {
                 let (_scale, rotation, translation) =
                     inst.transformation.to_scale_rotation_translation();
                 let inst_position = translation;
-                let inst_rotation = roation;
+                let inst_rotation = rotation;
 
                 let emissive_multiplier = Vec3::splat(inst.dynamic_parameters.emissive_multiplier);
 

--- a/crates/lib/kajiya/src/world_renderer.rs
+++ b/crates/lib/kajiya/src/world_renderer.rs
@@ -850,7 +850,7 @@ impl WorldRenderer {
             .instances
             .iter()
             .flat_map(|inst| {
-                let (_scale, roation, translation) =
+                let (_scale, rotation, translation) =
                     inst.transformation.to_scale_rotation_translation();
                 let inst_position = translation;
                 let inst_rotation = roation;


### PR DESCRIPTION
### Checklist

* [X ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ]X I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

changed rotation and translation in RayTracingInstanceDesc to transformation so it can handle scale
changed add_instance of WorldRenderer to take a Transformation instead of a position and rotation
changed set_instance_transform to take a Affine3A instead of a position and rotation
changed various functions in world_render.rs to handle this change
changed ray_tracer.rs and raster_mesh.rs to deal with the new transformation 
changed the hello example to handle the above changes
