### PR TITLE
Recompile libdxcompiler.so to remove depencency on libtinfo.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Operating systems:
 * Linux
 
 ### (Some) Linux dependencies
-* `libtinfo5`
 * `uuid-dev`
 * In case the bundled `libdxcompiler.so` doesn't work: https://github.com/microsoft/DirectXShaderCompiler#downloads
 


### PR DESCRIPTION
At the moment, attempting to run kajiya on my arch linux install (on https://github.com/EmbarkStudios/kajiya/pull/46) fails with:

```
A turbosloth LazyWorker "kajiya_backend::shader_compiler::CompileShader" failed

Caused by:
    Failed to load library "./libdxcompiler.so": DlOpen { desc: "libtinfo.so.5: cannot open shared object file: No such file or directory" }
```

Running `ldd libdxcompiler.so` lists the following dynamic library dependencies:
```
        linux-vdso.so.1 (0x00007ffc0df9b000)
	librt.so.1 => /usr/lib/librt.so.1 (0x00007f28f59e1000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f28f59da000)
	libtinfo.so.5 => not found
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f28f59b9000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007f28f599f000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f28f585b000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f28f5643000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f28f5628000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f28f545c000)
	/usr/lib64/ld-linux-x86-64.so.2 (0x00007f28f710d000)
```

The missing one, `libtinfo.so.5` is not installable on arch. The `core/ncurses` package (version `6.3-1`) provided `libtinfo.6`, but this newer version is not compatible. This library is literally only used for the `terminalHasColors` function and is useless in `libdxcompiler.so` which should not be printing anything. The solution to this is to either bundle `libtinfo.5` which is gross, or to recompile `libdxcompiler.so`  without terminfo like so:

```
git clone https://github.com/Microsoft/DirectXShaderCompiler --recursive
cd DirectXShaderCompiler
mkdir build
cd build
cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -C ../cmake/caches/PredefinedParams.cmake
ninja
```

The generated library no longer depends on it:

```
        linux-vdso.so.1 (0x00007ffdea17a000)
	librt.so.1 => /usr/lib/librt.so.1 (0x00007f0ba0958000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f0ba0951000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f0ba0930000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007f0ba0916000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f0ba0700000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f0ba05bc000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f0ba059f000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f0ba03d3000)
	/usr/lib64/ld-linux-x86-64.so.2 (0x00007f0ba24e4000)
```

The compiled library is a bit bigger, but I believe that is because the original one was compiled on Windows or something along those lines.

Instead of merging in random binaries it might be better for someone at Embark to recompile it themselves.