### PR TITLE
Improve hidpi handling in `kajiya-imgui`

### DIFF
--- a/crates/lib/kajiya-imgui/src/imgui_backend.rs
+++ b/crates/lib/kajiya-imgui/src/imgui_backend.rs
@@ -43,7 +43,7 @@ impl ImGuiBackend {
         {
             use imgui::{FontConfig, FontGlyphRanges, FontSource};
 
-            let hidpi_factor = imgui_platform.hidpi_factor();
+            let hidpi_factor = window.scale_factor();
             let font_size = (13.0 * hidpi_factor) as f32;
             imgui.fonts().add_font(&[
                 FontSource::DefaultFontData {
@@ -62,8 +62,6 @@ impl ImGuiBackend {
                     }),
                 },
             ]);
-
-            imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
         }
 
         let imgui_renderer = {


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I'm not entirely sure if this is the right way to fix this. There might be some context I'm missing here. At the moment `kajiya-imgui` has two problems:

* `imgui_platform.hidpi_factor()` incorrectly returns `1.0` while `window.scale_factor()` correctly returns `2.0`.
* The line `imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;` seems to negate any changes made to the font size.

This results in the gui being illegibly tiny on a hiDPI screen:

<img width="1392" alt="Screen Shot 2022-02-05 at 17 00 38" src="https://user-images.githubusercontent.com/13566135/152649149-0d26a6c5-2a7d-4287-a985-25390ba1f603.png">

After:

<img width="1392" alt="Screen Shot 2022-02-05 at 17 01 19" src="https://user-images.githubusercontent.com/13566135/152649154-a0794a17-ed1f-4bba-9971-a0a682ec8b3b.png">