### PR TITLE
Fix crashes on new drivers

### DIFF
--- a/crates/lib/kajiya-backend/src/vulkan/device.rs
+++ b/crates/lib/kajiya-backend/src/vulkan/device.rs
@@ -60,8 +60,7 @@ impl PendingResourceReleases {
 
 pub struct DeviceFrame {
     //pub(crate) linear_allocator_pool: vk_mem::AllocatorPool,
-    pub swapchain_acquired_semaphore: Option<vk::Semaphore>,
-    pub rendering_complete_semaphore: Option<vk::Semaphore>,
+    pub swapchain_acquired_semaphore: vk::Semaphore,
     pub main_command_buffer: CommandBuffer,
     pub presentation_command_buffer: CommandBuffer,
     pub pending_resource_releases: Mutex<PendingResourceReleases>,
@@ -125,8 +124,12 @@ impl DeviceFrame {
                 info
             })
             .expect("linear allocator"),*/
-            swapchain_acquired_semaphore: None,
-            rendering_complete_semaphore: None,
+            swapchain_acquired_semaphore:
+                unsafe {
+                    device
+                        .create_semaphore(&vk::SemaphoreCreateInfo::default(), None)
+                }
+                .unwrap(),
             main_command_buffer: CommandBuffer::new(device, queue_family).unwrap(),
             presentation_command_buffer: CommandBuffer::new(device, queue_family).unwrap(),
             pending_resource_releases: Default::default(),

--- a/crates/lib/kajiya-rg/src/renderer.rs
+++ b/crates/lib/kajiya-rg/src/renderer.rs
@@ -217,7 +217,7 @@ impl Renderer {
         // This can block, so we're doing it as late as possible.
 
         let swapchain_image = swapchain
-            .acquire_next_image()
+            .acquire_next_image(current_frame.swapchain_acquired_semaphore)
             .ok()
             .expect("swapchain image");
 
@@ -266,7 +266,7 @@ impl Renderer {
                 let submit_info = [vk::SubmitInfo::builder()
                     .wait_semaphores(std::slice::from_ref(&swapchain_image.acquire_semaphore))
                     .signal_semaphores(std::slice::from_ref(
-                        &swapchain_image.rendering_finished_semaphore,
+                        &swapchain_image.ready_for_present_semaphore,
                     ))
                     .wait_dst_stage_mask(&[vk::PipelineStageFlags::COMPUTE_SHADER])
                     .command_buffers(std::slice::from_ref(&presentation_cb.raw))

--- a/crates/lib/kajiya/src/renderers/ircache.rs
+++ b/crates/lib/kajiya/src/renderers/ircache.rs
@@ -19,7 +19,7 @@ use rg::BindMutToSimpleRenderPass;
 use rust_shaders_shared::frame_constants::{IrcacheCascadeConstants, IRCACHE_CASCADE_COUNT};
 use vk::BufferUsageFlags;
 
-use crate::renderers::prefix_scan::inclusive_prefix_scan_u32_1m;
+use crate::renderers::prefix_scan::{self, inclusive_prefix_scan_u32_1m};
 
 use super::wrc::WrcRenderState;
 
@@ -314,7 +314,7 @@ impl IrcacheRenderer {
         };
 
         let mut entry_occupancy_buf = rg.create(BufferDesc::new_gpu_only(
-            size_of::<u32>() * MAX_ENTRIES,
+            size_of::<u32>() * prefix_scan::MIN_BUFFER_ELEMENTS,
             vk::BufferUsageFlags::empty(),
         ));
 

--- a/crates/lib/kajiya/src/renderers/prefix_scan.rs
+++ b/crates/lib/kajiya/src/renderers/prefix_scan.rs
@@ -7,8 +7,11 @@ use kajiya_backend::{
 };
 use kajiya_rg::{self as rg, SimpleRenderPass};
 
+// see `inclusive_prefix_scan.hlsl`
+const SEGMENT_SIZE: usize = 1024;
+pub const MIN_BUFFER_ELEMENTS: usize = SEGMENT_SIZE * SEGMENT_SIZE;
+
 pub fn inclusive_prefix_scan_u32_1m(rg: &mut rg::RenderGraph, input_buf: &mut rg::Handle<Buffer>) {
-    const SEGMENT_SIZE: usize = 1024;
 
     SimpleRenderPass::new_compute(
         rg.add_pass("_prefix scan 1"),


### PR DESCRIPTION
Fixes two issues surfaced by newer nvidia drivers

1. It is now common for the driver to return swapchain images out-of-order, which crashes on an assert. Simply removing the assert is incorrect given this behavior and would result in overlapping use of the `rendering_complete` semaphores. Instead I moved the acquire semaphore into the frame data, to make sure there are enough if the number of frames is increased in the future (frames in flight is the bound on acquire semaphores). I then renamed `rendering_complete` to `ready_for_present` semaphores in the swapchain, which I think is a bit more descriptive of exactly their purpose, and index them based on the returned presentation index from the driver. In this way we guarantee that the `ready_for_present` semaphore is not in use when we wait on it before presentation.

2. The `prefix_scan` regime always accesses out to `SEGMENT_SIZE * SEGMENT_SIZE` (currently 1024 * 1024) element in the input buffer. Previously, we were passing it a buffer with `MAX_ENTRIES` elements (which is only 1024 * 64). So, we were accessing out of bounds quite dramatically. Probably the better solution here would be to make it adapt to the input buffer size dynamically and/or reduce the static size to match `MAX_ENTRIES`, but I haven't gone through the algorithm closely enough to adapt it yet